### PR TITLE
fix feature : update isOnlyEmoji

### DIFF
--- a/src/utils/isOnlyEmoji.spec.ts
+++ b/src/utils/isOnlyEmoji.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-// import isOnlyEmojiV1 from './isOnlyEmoji'
 import isOnlyEmoji from './isOnlyEmoji'
 
 describe('isOnlyEmoji', () => {

--- a/src/utils/isOnlyEmoji.spec.ts
+++ b/src/utils/isOnlyEmoji.spec.ts
@@ -1,30 +1,47 @@
 import { describe, expect, it } from 'vitest'
 
-import isOnlyEmoji from './isOnlyEmoji.js'
+// import isOnlyEmojiV1 from './isOnlyEmoji'
+import isOnlyEmoji from './isOnlyEmoji'
 
 describe('isOnlyEmoji', () => {
   it.each([
     { msg: '🫠' },
     { msg: '🅰️' },
-    { msg: '🅾' },
+    { msg: ' 🅾 🅾 🅾 🅾   🅾' },
     { msg: '<:test:000>' },
-    { msg: '1️⃣' },
+    { msg: '<a:test:111>' },
+    { msg: '<:ShareX_0RB3:1108771953776537701>' },
+    { msg: '<:Test:1108771953776537701>' },
+    { msg: '🅾🫠' },
+    { msg: '🏻 🏼' },
+    { msg: '👩🏾‍❤‍💋‍👩🏼' },
+    { msg: '👩🏾‍❤‍💋‍👩🏼\n🅾\n<:test:000>' },
+    //case of variation selector (0xFE0F)
+    { msg: '0️⃣' },
+    { msg: `  1️⃣ ` },
+    { msg: '#️⃣ *️⃣ 0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟' },
+    { msg: '1⃣' },
   ])('should match emoji ($msg)', async ({ msg }) => {
     expect(isOnlyEmoji(msg)).toBeTruthy()
   })
 
-  it.each([{ msg: '' }, { msg: 'hello' }, { msg: 'a' }, { msg: '<html>' }])(
-    'should not match emoji ($msg)',
-    async ({ msg }) => {
-      expect(isOnlyEmoji(msg)).toBeFalsy()
-    },
-  )
-
-  it('should not match emoji with text', async () => {
-    expect(isOnlyEmoji('hello 🫠')).toBeFalsy()
-  })
-
-  it('should not match messages with only numbers', async () => {
-    expect(isOnlyEmoji('1 2 3')).toBeFalsy()
+  it.each([
+    { msg: '' },
+    { msg: 'hello' },
+    { msg: 'a' },
+    { msg: '<html>' },
+    { msg: '1 2 3' },
+    { msg: '1️⃣0' },
+    { msg: '-1' },
+    { msg: '0x 000' },
+    { msg: '<:ShareX_0000 :>' },
+    { msg: 'Test : ' },
+    { msg: ':Imao' },
+    { msg: 'hello 🫠🫠🫠' },
+    { msg: `hi <:ShareX_00000:>` },
+    { msg: `#20` },
+    { msg: `0000\n00 2131⃣33` },
+  ])('should not match emoji ($msg)', async ({ msg }) => {
+    expect(isOnlyEmoji(msg)).toBeFalsy()
   })
 })

--- a/src/utils/isOnlyEmoji.ts
+++ b/src/utils/isOnlyEmoji.ts
@@ -7,7 +7,6 @@ export default (message: string): boolean => {
     const unicoded = emoji
       .map((emo) => emo.codePointAt(0))
       .filter((codePoint): codePoint is number => codePoint !== undefined)
-    // console.log(unicoded)
     // Check if have any number -> not an emoji
     for (let index = 0; index < unicoded.length; index++) {
       if (isEmojiNumber(unicoded[index], unicoded[index + 1])) {

--- a/src/utils/isOnlyEmoji.ts
+++ b/src/utils/isOnlyEmoji.ts
@@ -3,17 +3,18 @@ const emojiRegex =
 export default (message: string): boolean => {
   const emoji = message.match(emojiRegex)
   if (emoji !== null) {
-    const unicoded = emoji.map((emo) => {
-      return emo.codePointAt(0)
-    })
-    for (const [index, value] of unicoded.entries()) {
-      // the condition after number is to detect the unicode 0xFE0F next to number which mean to convert normal number to it emoji alternative.
-      if (
-        value !== undefined &&
-        isNumber(value) &&
-        index + 1 <= unicoded.length &&
-        unicoded[index + 1] !== 0xfe_0f
-      ) {
+    // Convert each emoji to its Unicode code and filter out undefined
+    const unicoded = emoji
+      .map((emo) => emo.codePointAt(0))
+      .filter((codePoint): codePoint is number => codePoint !== undefined)
+    // console.log(unicoded)
+    // Check if have any number -> not an emoji
+    for (let index = 0; index < unicoded.length; index++) {
+      if (isEmojiNumber(unicoded[index], unicoded[index + 1])) {
+        // Skip the next unicode as we already checked it in isEmojiNumber function.
+        index++
+      } else if (unicoded[index] >= 0x30 && unicoded[index] <= 0x39) {
+        // If the current unicode is a number but not an emoji number, return false.
         return false
       }
     }
@@ -23,6 +24,15 @@ export default (message: string): boolean => {
   )
 }
 
-function isNumber(input: number): boolean {
-  return input >= 0x30 && input <= 0x39 //0x30 to 0x39 is range of number unicode from 0 to 9.
+function isEmojiNumber(input: number, nextInput: number): boolean {
+  // Unicode 0x30 to 0x39 is range of number from 0 to 9.
+  // The following unicode 0xFE0F denotes to Variation Selector-16
+  // which is used to convert normal number to it emoji alternative.
+  // The following unicode 0x20E3 denotes to Combining Enclosing Keycap
+  // which is used to convert number to keycap emoji.
+  return (
+    input >= 0x30 &&
+    input <= 0x39 &&
+    (nextInput === 0xfe_0f || nextInput === 0x20_e3)
+  )
 }


### PR DESCRIPTION
# Description
reopen from https://github.com/kaogeek/kaogeek-discord-bot/pull/127 due to a low quality commit msg

1. updated `isOnlyEmoji` now also checks for the Combining Enclosing Keycap (0x20E3), which is _another way_ to create keycap number emojis (like 1️⃣, 2️⃣, 3️⃣, etc) 
     - we can test it by copying a string from `isOnlyEmoji.spec.ts` at line 23
2. refactor the function for more readability.
3. add more test case

//emoji behaviour is so weird
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor or other

## Screenshot

![image](https://github.com/kaogeek/kaogeek-discord-bot/assets/67526393/113660d6-fa93-42f0-8889-20868b3cf33f)

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
