### PR TITLE
chore: make prettier warn

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ const config = {
     'no-constant-binary-expression': 'error',
     'import/no-cycle': 'warn',
     'import/no-duplicates': 'warn',
+    'prettier/prettier': 'warn',
     'unicorn/filename-case': [
       'error',
       {


### PR DESCRIPTION
# Description

Setting `prettier/prettier` to `warn` so that it is a bit more friendly for our eyes when we don't finish typing something.
Since we allow no more than 0 warnings, this has no difference.

## Type of change

- [X] Refactor or other

# Checklist:

- [X] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [X] I have performed a self-review of my own code