### PR TITLE
name checking

### DIFF
--- a/bot-config.example.toml
+++ b/bot-config.example.toml
@@ -1,6 +1,12 @@
 # To see the latest configuration values used in production, see this file:
 # https://github.com/creatorsgarten/kaogeek-discord-bot/blob/config/bot-config.toml
 
+[nameChecker]
+  patterns = [
+    { regexp = "examplebadname" },
+  ]
+  reportChannelId = "1108478073998938163"
+
 [nominations]
   enabledRoles = [
     # Contributor

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,5 +1,6 @@
 import { Events } from 'discord.js'
 
+import { checkName } from '@/features/nameChecker'
 import { defineEventHandler } from '@/types/defineEventHandler'
 
 export default defineEventHandler({
@@ -9,5 +10,6 @@ export default defineEventHandler({
     console.info(
       `[guildMemberAdd] "${member.user.tag}" [${member.id}] joined "${member.guild.name}" [${member.guild.id}]`,
     )
+    await checkName(member, botContext.runtimeConfiguration.data.nameChecker)
   },
 })

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -1,5 +1,6 @@
 import { Events } from 'discord.js'
 
+import { checkName } from '@/features/nameChecker'
 import { defineEventHandler } from '@/types/defineEventHandler'
 
 export default defineEventHandler({
@@ -21,6 +22,9 @@ export default defineEventHandler({
         )
       }
     }
+
+    await checkName(next, botContext.runtimeConfiguration.data.nameChecker)
+
     const previousRoles = new Set(previous.roles.cache.map((role) => role.id))
     const nextRoles = new Set(next.roles.cache.map((role) => role.id))
     const addedRoles = [...nextRoles].filter((role) => !previousRoles.has(role))

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -4,6 +4,7 @@ import guildMemberAdd from './guildMemberAdd'
 import guildMemberRemove from './guildMemberRemove'
 import guildMemberUpdate from './guildMemberUpdate'
 import interactionCreate from './interactionCreate'
+import messageCreate from './messageCreate'
 import preventEmojiSpam from './preventEmojiSpam'
 import ready from './ready'
 import stickyMessageHandler from './stickyMessageHandler'
@@ -15,6 +16,7 @@ export default [
   guildMemberRemove,
   guildMemberUpdate,
   interactionCreate,
+  messageCreate,
   preventEmojiSpam,
   stickyMessageHandler,
   stickyMessageCreate,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,0 +1,17 @@
+import { Events } from 'discord.js'
+
+import { checkName } from '@/features/nameChecker'
+import { defineEventHandler } from '@/types/defineEventHandler'
+
+export default defineEventHandler({
+  eventName: Events.MessageCreate,
+  once: true,
+  execute: async (botContext, message) => {
+    if (message.member) {
+      await checkName(
+        message.member,
+        botContext.runtimeConfiguration.data.nameChecker,
+      )
+    }
+  },
+})

--- a/src/features/nameChecker/checkNameAgainstPatterns.spec.ts
+++ b/src/features/nameChecker/checkNameAgainstPatterns.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+
+import { checkNameAgainstPatterns } from './checkNameAgainstPatterns'
+
+test('case insensitive', async () => {
+  expect(checkNameAgainstPatterns('Test', [{ regexp: 'test' }])).toBeTruthy()
+})
+
+test('whitespace tolerance', async () => {
+  expect(checkNameAgainstPatterns('t e s t', [{ regexp: 'test' }])).toBeTruthy()
+})
+
+test('not match', async () => {
+  expect(checkNameAgainstPatterns('Innocent', [{ regexp: 'test' }])).toBeFalsy()
+})

--- a/src/features/nameChecker/checkNameAgainstPatterns.ts
+++ b/src/features/nameChecker/checkNameAgainstPatterns.ts
@@ -1,0 +1,29 @@
+import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
+
+import { compiled } from '.'
+
+type Pattern = RuntimeConfigurationSchema['nameChecker']['patterns'][number]
+
+export function checkNameAgainstPatterns(
+  name: string,
+  patterns: Pattern[],
+  logError = console.error,
+): RegExp | undefined {
+  for (const pattern of patterns) {
+    try {
+      let regexp = compiled.get(pattern.regexp)
+      if (!regexp) {
+        regexp = new RegExp(pattern.regexp, 'i')
+        compiled.set(pattern.regexp, regexp)
+      }
+      if (regexp.test(name) || regexp.test(name.replaceAll(/\s+/g, ''))) {
+        return regexp
+      }
+    } catch (error) {
+      logError(
+        `Unable to process pattern "${pattern}" against name "${name}"`,
+        error,
+      )
+    }
+  }
+}

--- a/src/features/nameChecker/index.ts
+++ b/src/features/nameChecker/index.ts
@@ -1,0 +1,41 @@
+import { GuildMember } from 'discord.js'
+
+import { Environment } from '@/config'
+import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
+
+import { checkNameAgainstPatterns } from './checkNameAgainstPatterns'
+
+export const compiled = new Map<string, RegExp>()
+const seen = new Map<string, number>()
+
+type Config = RuntimeConfigurationSchema['nameChecker']
+
+export async function checkName(member: GuildMember, config: Config) {
+  if (member.guild.id !== Environment.GUILD_ID) return
+
+  const { reportChannelId, patterns } = config
+  if (!patterns) {
+    return
+  }
+
+  const reportChannel = member.guild.channels.cache.get(reportChannelId)
+  if (!reportChannel) {
+    console.error('Unable to check name because report channel is missing')
+    return
+  }
+  if (!reportChannel.isTextBased()) {
+    console.error(
+      'Unable to check name because report channel is not text based',
+    )
+    return
+  }
+
+  const checkResult = checkNameAgainstPatterns(member.displayName, patterns)
+  if (checkResult) {
+    const isNew = !seen.has(member.id)
+    seen.set(member.id, Date.now())
+    if (isNew) {
+      await reportChannel?.send(`Name pattern match: ${member}`)
+    }
+  }
+}

--- a/src/utils/RuntimeConfigurationSchema.ts
+++ b/src/utils/RuntimeConfigurationSchema.ts
@@ -2,6 +2,13 @@ import { z } from 'zod'
 
 export const RuntimeConfigurationSchema = z
   .object({
+    nameChecker: z
+      .object({
+        patterns: z.array(z.object({ regexp: z.string() })).default([]),
+        reportChannelId: z.string().default(''),
+      })
+      .default({}),
+
     nominations: z
       .object({
         enabledRoles: z


### PR DESCRIPTION
# Description

some people are setting names that moderators consider offensive or inappropriate, moderators said "Flag จนเมื่อยมือออ"

this PR implements rudimentary name checking. it is done lazily - when a guild member posts a message or when they became active or change their name or join the server

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot

<img width="652" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/1e2920f9-2429-4f6e-ac79-e5c417b5ad82">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
