### PR TITLE
begin moving towards plugin system

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -6,7 +6,6 @@ import eventPlugins from './events/index'
 import { initStickyMessage } from './features/stickyMessage/index'
 import { BotContext } from './types/BotContext'
 import { CommandHandlerConfig } from './types/CommandHandlerConfig'
-import { EventHandlerConfig } from './types/EventHandlerConfig'
 import { Plugin } from './types/Plugin'
 import { RuntimeConfiguration } from './utils/RuntimeConfiguration'
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,4 @@
-import { AnyEventHandlerConfig } from '@/types/EventHandlerConfig'
+import { Plugin } from '@/types/Plugin'
 
 import guildMemberAdd from './guildMemberAdd'
 import guildMemberRemove from './guildMemberRemove'
@@ -20,4 +20,4 @@ export default [
   stickyMessageCreate,
   stickyMessageRemove,
   ready,
-] satisfies AnyEventHandlerConfig[]
+] satisfies Plugin[]

--- a/src/events/preventEmojiSpam.ts
+++ b/src/events/preventEmojiSpam.ts
@@ -4,6 +4,7 @@ import { defineEventHandler } from '@/types/defineEventHandler'
 import isOnlyEmoji from '@/utils/isOnlyEmoji'
 
 export default defineEventHandler({
+  displayName: 'preventEmojiSpam',
   eventName: Events.MessageCreate,
   once: false,
   execute: async ({ runtimeConfiguration }, message) => {

--- a/src/events/stickyMessageHandler.ts
+++ b/src/events/stickyMessageHandler.ts
@@ -13,6 +13,7 @@ import { defineEventHandler } from '@/types/defineEventHandler'
 import { getCache } from '@/utils/cache'
 
 export default defineEventHandler({
+  displayName: 'stickyMessageHandler',
   eventName: Events.MessageCreate,
   once: false,
   execute: async (_botContext, message) => {

--- a/src/events/stickyMessageRemove.ts
+++ b/src/events/stickyMessageRemove.ts
@@ -8,6 +8,7 @@ import { defineEventHandler } from '@/types/defineEventHandler'
 import { getCache, removeCache } from '@/utils/cache'
 
 export default defineEventHandler({
+  displayName: 'stickyMessageRemove',
   eventName: Events.MessageCreate,
   once: false,
   execute: async (_botContext, message) => {

--- a/src/events/stickyMessageSet.ts
+++ b/src/events/stickyMessageSet.ts
@@ -14,6 +14,7 @@ import { defineEventHandler } from '../types/defineEventHandler'
 import { getCache, saveCache } from '../utils/cache'
 
 export default defineEventHandler({
+  displayName: 'stickyMessageSet',
   eventName: Events.MessageCreate,
   once: false,
   execute: async (_botContext, message) => {

--- a/src/types/Plugin.ts
+++ b/src/types/Plugin.ts
@@ -1,0 +1,6 @@
+import { PluginContext } from './PluginContext'
+
+export interface Plugin {
+  name: string
+  setup(pluginContext: PluginContext): void
+}

--- a/src/types/PluginContext.ts
+++ b/src/types/PluginContext.ts
@@ -1,0 +1,9 @@
+import { ClientEvents } from 'discord.js'
+
+import { EventHandlerConfig } from './EventHandlerConfig'
+
+export interface PluginContext {
+  addEventHandler<K extends keyof ClientEvents>(
+    handler: EventHandlerConfig<K>,
+  ): void
+}

--- a/src/types/defineEventHandler.ts
+++ b/src/types/defineEventHandler.ts
@@ -1,9 +1,16 @@
 import { ClientEvents } from 'discord.js'
 
 import { EventHandlerConfig } from './EventHandlerConfig'
+import { Plugin } from './Plugin'
+import { definePlugin } from './definePlugin'
 
 export function defineEventHandler<K extends keyof ClientEvents>(
-  config: EventHandlerConfig<K>,
-): EventHandlerConfig<K> {
-  return config
+  config: EventHandlerConfig<K> & { displayName?: string },
+): Plugin {
+  return definePlugin({
+    name: `LegacyEventHandlerPlugin[${config.displayName ?? config.eventName}]`,
+    setup: (plugin) => {
+      plugin.addEventHandler(config)
+    },
+  })
 }

--- a/src/types/defineEventHandler.ts
+++ b/src/types/defineEventHandler.ts
@@ -6,11 +6,21 @@ import { definePlugin } from './definePlugin'
 
 export function defineEventHandler<K extends keyof ClientEvents>(
   config: EventHandlerConfig<K> & { displayName?: string },
-): Plugin {
-  return definePlugin({
-    name: `LegacyEventHandlerPlugin[${config.displayName ?? config.eventName}]`,
-    setup: (plugin) => {
-      plugin.addEventHandler(config)
-    },
-  })
+): Plugin & { execute: EventHandlerConfig<K>['execute'] } {
+  return Object.assign(
+    definePlugin({
+      name: `LegacyEventHandlerPlugin[${
+        config.displayName ?? config.eventName
+      }]`,
+      setup: (plugin) => {
+        plugin.addEventHandler(config)
+      },
+    }),
+
+    // XXX: The `execute` function is not part of the plugin definition,
+    // but it is exposed here because some unit tests need to call it.
+    // Unit tests should not rely on implementation details like this,
+    // because they are hard to refactor.
+    { execute: config.execute },
+  )
 }

--- a/src/types/definePlugin.ts
+++ b/src/types/definePlugin.ts
@@ -1,0 +1,5 @@
+import { Plugin } from './Plugin'
+
+export function definePlugin(plugin: Plugin) {
+  return plugin
+}


### PR DESCRIPTION
# Description

right now the "events" folder start looking messy because it contains a mix of 3 things

- index file
- file named after an actual event
- file named after a functionality/feature

![image](https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/1ddcbb46-12be-4968-883f-4a7c3b81af53)

to fix this, i want to introduce a plugin system. each feature will be able to register multiple event handlers and commands. this refactor is being done in incremental steps.

- **step 1** (this PR) — introduce a plugin system and redefine event handlers in terms of plugins (avoid API changes)
- **step 2** — move event handlers from `events` folder into individual feature in the `features` folder
- **step 3** — introduce support for defining [application commands](https://discord.com/developers/docs/interactions/application-commands) inside a plugin
- **step 4** — move commands from the `commands` folder into individual feature in the `features` folder

after all 4 steps, eventually all the code related to a single feature will be put inside `features` and not scattered around the codebase in `commands`, `events`, `features`, `utils`, and `types`.

this makes code easy to delete. recommend reading — https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to

## Type of change

- [x] Refactor or other

## Screenshot

<img width="680" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/1a1d73ce-4051-4dbd-b280-a8486f9e936f">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
