### PR TITLE
plugin system part 3: define command handler in terms of plugin

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -6,7 +6,7 @@ import {
   Interaction,
 } from 'discord.js'
 
-import commands from './commands/index'
+import commandPlugins from './commands/index'
 import { Environment } from './config'
 import featurePlugins from './features'
 import { initStickyMessage } from './features/stickyMessage/stickyMessages'
@@ -51,8 +51,7 @@ export class Bot {
     this.client.once(Events.InteractionCreate, (interaction) =>
       this.onInteractionCreate(interaction),
     )
-    this.loadPlugins(featurePlugins)
-    this.loadCommandHandlers(commands)
+    this.loadPlugins([...commandPlugins, ...featurePlugins])
   }
 
   private loadPlugins(plugins: Plugin[]) {
@@ -65,6 +64,9 @@ export class Bot {
 
   private initializePlugin(plugin: Plugin) {
     plugin.setup({
+      addCommandHandler: (handler) => {
+        this.commands.set(handler.data.name, handler)
+      },
       addEventHandler: (handler) => {
         if (handler.once) {
           this.client.once(handler.eventName, (...arguments_) =>
@@ -78,12 +80,6 @@ export class Bot {
       },
     })
     console.log(`[PLUGIN] Initialized`, plugin.name)
-  }
-
-  private loadCommandHandlers(handlers: CommandHandlerConfig[]) {
-    for (const handler of handlers) {
-      this.commands.set(handler.data.name, handler)
-    }
   }
 
   private async onReady() {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -64,7 +64,7 @@ export class Bot {
 
   private initializePlugin(plugin: Plugin) {
     plugin.setup({
-      addCommandHandler: (handler) => {
+      addCommand: (handler) => {
         this.commands.set(handler.data.name, handler)
       },
       addEventHandler: (handler) => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,4 @@
-import { CommandHandlerConfig } from '@/types/CommandHandlerConfig'
+import { Plugin } from '@/types/Plugin'
 
 import ping from './info/ping'
 import activeThreads from './moderators/activeThreads'
@@ -22,4 +22,4 @@ export default [
   report,
   user,
   slowmode,
-] satisfies CommandHandlerConfig[]
+] satisfies Plugin[]

--- a/src/commands/moderators/activeThreads.ts
+++ b/src/commands/moderators/activeThreads.ts
@@ -15,12 +15,12 @@ import {
   getThreadStats,
 } from '@/features/threadPruner/index.js'
 import { BotContext } from '@/types/BotContext.js'
-import { CommandHandlerConfig } from '@/types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '@/types/defineCommandHandler'
 import { ActionSet } from '@/utils/ActionSet.js'
 import { generateTsv } from '@/utils/generateTsv.js'
 import { toLocalDate } from '@/utils/toLocalDate.js'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'active-threads',
     description: 'Get information and statistics about server threads',
@@ -87,7 +87,7 @@ export default {
     }
     await action.registeredAction.handler(action.interaction)
   },
-} satisfies CommandHandlerConfig
+})
 
 async function generateReport(
   botContext: BotContext,

--- a/src/commands/nominations/nominate.ts
+++ b/src/commands/nominations/nominate.ts
@@ -7,9 +7,9 @@ import {
 } from 'discord.js'
 
 import { prisma } from '@/prisma'
-import { CommandHandlerConfig } from '@/types/CommandHandlerConfig.js'
+import { defineCommandHandler } from '@/types/defineCommandHandler'
 
-export default {
+export default defineCommandHandler({
   data: {
     name: 'nominate',
     description: 'Nominates a user for a role',
@@ -146,7 +146,7 @@ export default {
       config.nominationsChannelId,
     )
   },
-} satisfies CommandHandlerConfig
+})
 
 async function updateNominationMessage(
   nominatedMember: GuildMember,

--- a/src/types/PluginContext.ts
+++ b/src/types/PluginContext.ts
@@ -4,7 +4,7 @@ import { CommandHandlerConfig } from './CommandHandlerConfig'
 import { EventHandlerConfig } from './EventHandlerConfig'
 
 export interface PluginContext {
-  addCommandHandler(handler: CommandHandlerConfig): void
+  addCommand(handler: CommandHandlerConfig): void
   addEventHandler<K extends keyof ClientEvents>(
     handler: EventHandlerConfig<K>,
   ): void

--- a/src/types/PluginContext.ts
+++ b/src/types/PluginContext.ts
@@ -1,8 +1,10 @@
 import { ClientEvents } from 'discord.js'
 
+import { CommandHandlerConfig } from './CommandHandlerConfig'
 import { EventHandlerConfig } from './EventHandlerConfig'
 
 export interface PluginContext {
+  addCommandHandler(handler: CommandHandlerConfig): void
   addEventHandler<K extends keyof ClientEvents>(
     handler: EventHandlerConfig<K>,
   ): void

--- a/src/types/PluginContext.ts
+++ b/src/types/PluginContext.ts
@@ -4,8 +4,15 @@ import { CommandHandlerConfig } from './CommandHandlerConfig'
 import { EventHandlerConfig } from './EventHandlerConfig'
 
 export interface PluginContext {
-  addCommand(handler: CommandHandlerConfig): void
+  /**
+   * Add an application command to the bot.
+   */
+  addCommand(config: CommandHandlerConfig): void
+
+  /**
+   * Add an event handler to the bot.
+   */
   addEventHandler<K extends keyof ClientEvents>(
-    handler: EventHandlerConfig<K>,
+    config: EventHandlerConfig<K>,
   ): void
 }

--- a/src/types/defineCommandHandler.ts
+++ b/src/types/defineCommandHandler.ts
@@ -1,5 +1,12 @@
 import { CommandHandlerConfig } from './CommandHandlerConfig'
+import { Plugin } from './Plugin'
+import { definePlugin } from './definePlugin'
 
-export function defineCommandHandler(config: CommandHandlerConfig) {
-  return config
+export function defineCommandHandler(config: CommandHandlerConfig): Plugin {
+  return definePlugin({
+    name: `legacyCommandHandler[${config.data.name}]`,
+    setup: (pluginContext) => {
+      pluginContext.addCommandHandler(config)
+    },
+  })
 }

--- a/src/types/defineCommandHandler.ts
+++ b/src/types/defineCommandHandler.ts
@@ -6,7 +6,7 @@ export function defineCommandHandler(config: CommandHandlerConfig): Plugin {
   return definePlugin({
     name: `legacyCommandHandler[${config.data.name}]`,
     setup: (pluginContext) => {
-      pluginContext.addCommandHandler(config)
+      pluginContext.addCommand(config)
     },
   })
 }


### PR DESCRIPTION
# Description

this PR updates `defineCommandHandlers` to be implemented in terms of plugin

- **step 1** ~~introduce a plugin system and redefine event handlers in terms of plugins (avoid API changes)~~
  - see: #143
- **step 2** — move event handlers from `events` folder into individual feature in the `features` folder
  - see #144 
- **step 3 (this PR)** — introduce support for defining [application commands](https://discord.com/developers/docs/interactions/application-commands) inside a plugin
- **step 4** — move commands from the `commands` folder into individual feature in the `features` folder

## Type of change

- [x] Refactor or other

## Screenshot

<img width="933" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/9bd2ae5a-ae12-4f86-894e-cd54a2f46748">

<!-- Please add a screenshot. This helps make it easier for us to review PRs. -->

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
