### PR TITLE
HOTFIX: interaction event handler registered with `once` instead of `on`

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -48,7 +48,7 @@ export class Bot {
 
   loadHandlers() {
     this.client.once(Events.ClientReady, () => this.onReady())
-    this.client.once(Events.InteractionCreate, (interaction) =>
+    this.client.on(Events.InteractionCreate, (interaction) =>
       this.onInteractionCreate(interaction),
     )
     this.loadPlugins([...commandPlugins, ...featurePlugins])


### PR DESCRIPTION
# Description

i used the wrong method to register an interaction handler

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshot

N/A

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
