### PR TITLE
add a logger module + initializers system + event handler error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,6 @@ COPY package.json ./
 COPY --chown=node:node --from=deps-prod /app/node_modules ./node_modules
 COPY --chown=node:node --from=deps-prod /app/prisma ./prisma
 COPY --chown=node:node --from=builder /app/dist ./dist
+COPY bot-config.example.toml ./
 
 CMD ["dist/index.js"]

--- a/smoke/docker-compose.yml
+++ b/smoke/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       BOT_TOKEN: dummy
       GUILD_ID: dummy
       MOD_CHANNEL_ID: dummy
+      BOT_CONFIG: file:./bot-config.example.toml

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -61,16 +61,16 @@ export class Bot {
     const log = this.createNewLogger(['[Bot.init]'])
     log.info(`Environment: ${this.isProduction ? 'Production' : 'Development'}`)
 
-    this.client.once(Events.ClientReady, () => this.onReady())
-    this.client.on(Events.InteractionCreate, (interaction) =>
-      this.onInteractionCreate(interaction),
-    )
-    this.loadPlugins(featurePlugins)
-
     const initialRuntimeConfig = await this.runtimeConfiguration.init()
     log.info(
       'Initial runtime configuration: ' + JSON.stringify(initialRuntimeConfig),
     )
+
+    this.client.once(Events.ClientReady, () => this.onReady())
+    this.client.on(Events.InteractionCreate, (interaction) =>
+      this.onInteractionCreate(interaction),
+    )
+    await this.loadPlugins(featurePlugins)
   }
 
   private async loadPlugins(plugins: Plugin[]) {

--- a/src/features/memberUpdateLogger/index.ts
+++ b/src/features/memberUpdateLogger/index.ts
@@ -9,8 +9,9 @@ export default definePlugin({
       eventName: Events.GuildMemberAdd,
       once: false,
       execute: async (botContext, member) => {
-        console.info(
-          `[guildMemberAdd] "${member.user.tag}" [${member.id}] joined "${member.guild.name}" [${member.guild.id}]`,
+        const { log } = botContext
+        log.info(
+          `"${member.user.tag}" [${member.id}] joined "${member.guild.name}" [${member.guild.id}]`,
         )
       },
     })
@@ -18,8 +19,9 @@ export default definePlugin({
       eventName: Events.GuildMemberRemove,
       once: false,
       execute: async (botContext, member) => {
-        console.info(
-          `[guildMemberRemove] "${member.user.tag}" [${member.id}] left "${member.guild.name}" [${member.guild.id}]`,
+        const { log } = botContext
+        log.info(
+          `"${member.user.tag}" [${member.id}] left "${member.guild.name}" [${member.guild.id}]`,
         )
       },
     })
@@ -27,18 +29,19 @@ export default definePlugin({
       eventName: Events.GuildMemberUpdate,
       once: false,
       execute: async (botContext, previous, next) => {
+        const { log } = botContext
         if (previous.nickname !== next.nickname) {
           if (!previous.nickname) {
-            console.info(
-              `[guildMemberUpdate] "${next.user.tag}" [${next.id}] set their nickname to "${next.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
+            log.info(
+              `"${next.user.tag}" [${next.id}] set their nickname to "${next.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
             )
           } else if (next.nickname) {
-            console.info(
-              `[guildMemberUpdate] "${next.user.tag}" [${next.id}] changed nickname from "${previous.nickname}" to "${next.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
+            log.info(
+              `"${next.user.tag}" [${next.id}] changed nickname from "${previous.nickname}" to "${next.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
             )
           } else {
-            console.info(
-              `[guildMemberUpdate] "${next.user.tag}" [${next.id}] removed their nickname "${previous.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
+            log.info(
+              `"${next.user.tag}" [${next.id}] removed their nickname "${previous.nickname}" in "${next.guild.name}" [${next.guild.id}]`,
             )
           }
         }
@@ -56,15 +59,15 @@ export default definePlugin({
         for (const roleId of addedRoles) {
           const role = next.guild.roles.cache.get(roleId)
           if (!role) continue
-          console.info(
-            `[guildMemberUpdate] "${next.user.tag}" [${next.id}] was given the role "${role.name}" [${role.id}] in "${next.guild.name}" [${next.guild.id}]`,
+          log.info(
+            `"${next.user.tag}" [${next.id}] was given the role "${role.name}" [${role.id}] in "${next.guild.name}" [${next.guild.id}]`,
           )
         }
         for (const roleId of removedRoles) {
           const role = previous.guild.roles.cache.get(roleId)
           if (!role) continue
-          console.info(
-            `[guildMemberUpdate] "${next.user.tag}" [${next.id}] was removed from the role "${role.name}" [${role.id}] in "${next.guild.name}" [${next.guild.id}]`,
+          log.info(
+            `"${next.user.tag}" [${next.id}] was removed from the role "${role.name}" [${role.id}] in "${next.guild.name}" [${next.guild.id}]`,
           )
         }
       },

--- a/src/features/messagePruner/pruneMessagesCommand.ts
+++ b/src/features/messagePruner/pruneMessagesCommand.ts
@@ -22,6 +22,7 @@ export const pruneMessagesCommand = defineCommand({
   ephemeral: true,
   execute: async (botContext, interaction) => {
     if (!interaction.guild || !interaction.isContextMenuCommand()) return
+    const { log } = botContext
 
     // Fetch reference message by target id
     const message = await interaction.channel?.messages.fetch(
@@ -111,14 +112,14 @@ export const pruneMessagesCommand = defineCommand({
         if (userMessages.size > 0) {
           try {
             await (channel as TextChannel).bulkDelete(userMessages)
-            console.info(
+            log.info(
               `Deleted ${userMessages.size} messages from ${
                 interaction.targetId
               } in channel ${(channel as TextChannel).name} (${channelId}).`,
             )
             numberDeleted += userMessages.size
           } catch (error) {
-            console.error('Error deleting messages:', error)
+            log.error('Error deleting messages:', error)
             if (error instanceof DiscordAPIError) {
               // Reply about the error
               //for error 400 : cant occur because the time period has been set for how many days to delete
@@ -135,7 +136,7 @@ export const pruneMessagesCommand = defineCommand({
       }
     }
     // Tell the user that the messages were successfully pruned
-    console.info(`Successfully pruned ${numberDeleted} messages.`)
+    log.info(`Successfully pruned ${numberDeleted} messages.`)
     await interaction.editReply({
       content: `Successfully prune messages. Number of messages deleted: ${numberDeleted}`,
       components: [],

--- a/src/features/nameChecker/checkName.ts
+++ b/src/features/nameChecker/checkName.ts
@@ -1,15 +1,16 @@
 import { GuildMember } from 'discord.js'
 
 import { Environment } from '@/config'
-import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
+import { BotContext } from '@/types/BotContext'
 
 import { checkNameAgainstPatterns } from './checkNameAgainstPatterns'
 
 export const compiled = new Map<string, RegExp>()
 const seen = new Map<string, number>()
-type Config = RuntimeConfigurationSchema['nameChecker']
 
-export async function checkName(member: GuildMember, config: Config) {
+export async function checkName(member: GuildMember, botContext: BotContext) {
+  const { log, runtimeConfiguration } = botContext
+  const config = runtimeConfiguration.data.nameChecker
   if (member.guild.id !== Environment.GUILD_ID) return
 
   const { reportChannelId, patterns } = config
@@ -19,21 +20,26 @@ export async function checkName(member: GuildMember, config: Config) {
 
   const reportChannel = member.guild.channels.cache.get(reportChannelId)
   if (!reportChannel) {
-    console.error('Unable to check name because report channel is missing')
+    log.error('Unable to check name because report channel is missing')
     return
   }
   if (!reportChannel.isTextBased()) {
-    console.error(
-      'Unable to check name because report channel is not text based',
-    )
+    log.error('Unable to check name because report channel is not text based')
     return
   }
 
-  const checkResult = checkNameAgainstPatterns(member.displayName, patterns)
+  const checkResult = checkNameAgainstPatterns(
+    member.displayName,
+    patterns,
+    log,
+  )
   if (checkResult) {
     const isNew = !seen.has(member.id)
     seen.set(member.id, Date.now())
     if (isNew) {
+      log.info(
+        `Name pattern match ${checkResult}: "${member.displayName}" (${member.id})`,
+      )
       await reportChannel?.send(`Name pattern match: ${member}`)
     }
   }

--- a/src/features/nameChecker/checkNameAgainstPatterns.ts
+++ b/src/features/nameChecker/checkNameAgainstPatterns.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@/types/Logger'
 import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
 
 import { compiled } from './checkName'
@@ -7,7 +8,7 @@ type Pattern = RuntimeConfigurationSchema['nameChecker']['patterns'][number]
 export function checkNameAgainstPatterns(
   name: string,
   patterns: Pattern[],
-  logError = console.error,
+  log: Logger = console,
 ): RegExp | undefined {
   for (const pattern of patterns) {
     try {
@@ -20,7 +21,7 @@ export function checkNameAgainstPatterns(
         return regexp
       }
     } catch (error) {
-      logError(
+      log.error(
         `Unable to process pattern "${pattern}" against name "${name}"`,
         error,
       )

--- a/src/features/nameChecker/index.ts
+++ b/src/features/nameChecker/index.ts
@@ -10,33 +10,22 @@ export default definePlugin({
     pluginContext.addEventHandler({
       eventName: Events.GuildMemberAdd,
       execute: async (botContext, member) => {
-        await checkName(
-          member,
-          botContext.runtimeConfiguration.data.nameChecker,
-        )
+        await checkName(member, botContext)
       },
     })
 
     pluginContext.addEventHandler({
       eventName: Events.GuildMemberUpdate,
       execute: async (botContext, oldMember, newMember) => {
-        await checkName(
-          newMember,
-          botContext.runtimeConfiguration.data.nameChecker,
-        )
+        await checkName(newMember, botContext)
       },
     })
 
     pluginContext.addEventHandler({
       eventName: Events.MessageCreate,
       execute: async (botContext, message) => {
-        if (!message.member) {
-          return
-        }
-        await checkName(
-          message.member,
-          botContext.runtimeConfiguration.data.nameChecker,
-        )
+        if (!message.member) return
+        await checkName(message.member, botContext)
       },
     })
   },

--- a/src/features/preventEmojiSpam/index.ts
+++ b/src/features/preventEmojiSpam/index.ts
@@ -9,18 +9,19 @@ export default definePlugin({
     pluginContext.addEventHandler({
       eventName: Events.MessageCreate,
       once: false,
-      execute: async ({ runtimeConfiguration }, message) => {
+      execute: async (botContext, message) => {
+        const { runtimeConfiguration, log } = botContext
         // if has only emoji -> delete message
         if (isOnlyEmoji(message.content)) {
           try {
-            console.info(
-              `[preventEmojiSpam] Message with only emoji: ${message.id} by ${message.author}`,
+            log.info(
+              `Message with only emoji: ${message.id} by ${message.author}`,
             )
             if (runtimeConfiguration.data.preventEmojiSpam.enabled) {
               await message.delete()
             }
           } catch (error) {
-            console.error(error)
+            log.error('Unable to process message', error)
           }
         }
       },

--- a/src/features/stickyMessage/index.ts
+++ b/src/features/stickyMessage/index.ts
@@ -5,6 +5,7 @@ import { definePlugin } from '@/types/definePlugin'
 import { stickyMessageHandler } from './stickyMessageHandler'
 import { stickyMessageRemove } from './stickyMessageRemove'
 import { stickyMessageSet } from './stickyMessageSet'
+import { initStickyMessage } from './stickyMessages'
 
 export default definePlugin({
   name: 'stickyMessage',
@@ -24,5 +25,8 @@ export default definePlugin({
       execute: async (botContext, message) =>
         stickyMessageRemove(message, botContext.log),
     })
+    pluginContext.addInitializer((botContext) =>
+      initStickyMessage(botContext.log),
+    )
   },
 })

--- a/src/features/stickyMessage/index.ts
+++ b/src/features/stickyMessage/index.ts
@@ -11,15 +11,18 @@ export default definePlugin({
   setup: (pluginContext) => {
     pluginContext.addEventHandler({
       eventName: Events.MessageCreate,
-      execute: async (_botContext, message) => stickyMessageHandler(message),
+      execute: async (botContext, message) =>
+        stickyMessageHandler(message, botContext.log),
     })
     pluginContext.addEventHandler({
       eventName: Events.MessageCreate,
-      execute: async (_botContext, message) => stickyMessageSet(message),
+      execute: async (botContext, message) =>
+        stickyMessageSet(message, botContext.log),
     })
     pluginContext.addEventHandler({
       eventName: Events.MessageCreate,
-      execute: async (_botContext, message) => stickyMessageRemove(message),
+      execute: async (botContext, message) =>
+        stickyMessageRemove(message, botContext.log),
     })
   },
 })

--- a/src/features/stickyMessage/stickyMessageHandler.spec.ts
+++ b/src/features/stickyMessage/stickyMessageHandler.spec.ts
@@ -66,6 +66,7 @@ describe('stickyMessageHandler', () => {
     expect(stickyMessage.pushMessageToBottom).toHaveBeenCalledWith(
       message,
       stickyMessageEntity,
+      expect.anything(),
     )
   })
 

--- a/src/features/stickyMessage/stickyMessageHandler.ts
+++ b/src/features/stickyMessage/stickyMessageHandler.ts
@@ -2,6 +2,7 @@ import { Message } from 'discord.js'
 
 import { StickyMessage } from '@prisma/client'
 
+import { Logger } from '@/types/Logger'
 import { getCache } from '@/utils/cache'
 
 import { isChannelLock } from './channelLock'
@@ -12,7 +13,10 @@ import {
   pushMessageToBottom,
 } from './stickyMessages'
 
-export async function stickyMessageHandler(message: Message) {
+export async function stickyMessageHandler(
+  message: Message,
+  log: Logger = console,
+) {
   // TODO: fix this to handle the command dynamically
   if (
     message.content.startsWith('?stickao-set') ||
@@ -42,5 +46,5 @@ export async function stickyMessageHandler(message: Message) {
   }
 
   // if message need to update -> push sticky message to bottom
-  await pushMessageToBottom(message, stickyMessage)
+  await pushMessageToBottom(message, stickyMessage, log)
 }

--- a/src/features/stickyMessage/stickyMessageRemove.ts
+++ b/src/features/stickyMessage/stickyMessageRemove.ts
@@ -3,12 +3,16 @@ import { Message, PermissionsBitField, TextChannel } from 'discord.js'
 import { StickyMessage } from '@prisma/client'
 
 import { prisma } from '@/prisma'
+import { Logger } from '@/types/Logger'
 import { getCache, removeCache } from '@/utils/cache'
 import { sendDm } from '@/utils/sendDm'
 
 import { STICKY_CACHE_PREFIX } from './stickyMessages'
 
-export async function stickyMessageRemove(message: Message) {
+export async function stickyMessageRemove(
+  message: Message,
+  log: Logger = console,
+) {
   if (!message.content.startsWith('?stickao-remove')) {
     return
   }
@@ -46,7 +50,7 @@ export async function stickyMessageRemove(message: Message) {
 
       await stickyMessage.delete()
 
-      console.info(`Sticky message removed: ${stickyMessageEntity.message}`)
+      log.info(`Sticky message removed: ${stickyMessageEntity.message}`)
       await sendDm(message, {
         content: 'Successfully removed the sticky message.',
       })
@@ -56,7 +60,7 @@ export async function stickyMessageRemove(message: Message) {
       })
     }
   } catch (error) {
-    console.error(`Error removing sticky message: ${(error as Error).message}`)
+    log.error(`Error removing sticky message:`, error)
     await sendDm(message, {
       content: 'An error occurred while removing the sticky message.',
     })

--- a/src/features/stickyMessage/stickyMessageSet.ts
+++ b/src/features/stickyMessage/stickyMessageSet.ts
@@ -8,12 +8,16 @@ import {
 import { StickyMessage } from '@prisma/client'
 
 import { prisma } from '@/prisma'
+import { Logger } from '@/types/Logger'
 import { getCache, saveCache } from '@/utils/cache'
 import { sendDm } from '@/utils/sendDm'
 
 import { STICKY_CACHE_PREFIX } from './stickyMessages'
 
-export async function stickyMessageSet(message: Message) {
+export async function stickyMessageSet(
+  message: Message,
+  log: Logger = console,
+) {
   if (!message.content.startsWith('?stickao-set')) {
     return
   }
@@ -86,12 +90,12 @@ export async function stickyMessageSet(message: Message) {
     saveCache(`${STICKY_CACHE_PREFIX}-${message.channelId}`, stickyMessage)
 
     // Successfully create sticky message
-    console.info(`Sticky message saved: ${messageContent}`)
+    log.info(`Sticky message saved: ${messageContent}`)
     await sendDm(message, {
       content: 'Successfully created sticky message.',
     })
   } catch (error) {
-    console.error(`Error creating sticky message: ${(error as Error).message}`)
+    log.error(`Unable to create sticky message:`, error)
     await sendDm(message, {
       content: 'An error occurred while creating the sticky message.',
     })

--- a/src/features/stickyMessage/stickyMessages.spec.ts
+++ b/src/features/stickyMessage/stickyMessages.spec.ts
@@ -34,7 +34,7 @@ describe('initStickyMessage', () => {
     vi.spyOn(messageCounter, 'resetCounter')
     prisma.stickyMessage.findMany = vi.fn().mockResolvedValue(messages)
 
-    await initStickyMessage()
+    await initStickyMessage(console)
 
     expect(prisma.stickyMessage.findMany).toHaveBeenCalled()
   })
@@ -43,7 +43,7 @@ describe('initStickyMessage', () => {
     vi.spyOn(messageCounter, 'resetCounter')
     prisma.stickyMessage.findMany = vi.fn().mockResolvedValue(messages)
 
-    await initStickyMessage()
+    await initStickyMessage(console)
 
     expect(messageCounter.resetCounter).toHaveBeenCalledWith(channelId)
   })

--- a/src/features/stickyMessage/stickyMessages.ts
+++ b/src/features/stickyMessage/stickyMessages.ts
@@ -19,12 +19,13 @@ export const STICKY_MODAL_TIMEOUT = 60_000
 /**
  *  Init sticky message memory cache
  */
-export async function initStickyMessage() {
+export async function initStickyMessage(log: Logger) {
   const messages = await prisma.stickyMessage.findMany()
   for (const message of messages) {
     saveCache(`${STICKY_CACHE_PREFIX}-${message.channelId}`, message)
     resetCounter(message.channelId)
   }
+  log.info(`Loaded ${messages.length} sticky messages`)
 }
 
 /**

--- a/src/features/stickyMessage/stickyMessages.ts
+++ b/src/features/stickyMessage/stickyMessages.ts
@@ -4,6 +4,7 @@ import { StickyMessage } from '@prisma/client'
 
 import { Environment } from '@/config'
 import { prisma } from '@/prisma'
+import { Logger } from '@/types/Logger'
 import { saveCache } from '@/utils/cache'
 
 import { lockChannel, unlockChannel } from './channelLock'
@@ -36,6 +37,7 @@ export async function initStickyMessage() {
 export async function pushMessageToBottom(
   message: Message,
   stickyMessage: StickyMessage,
+  log: Logger = console,
 ): Promise<void> {
   // lock channel
   lockChannel(message.channelId)
@@ -72,11 +74,9 @@ export async function pushMessageToBottom(
   } catch (error) {
     // in case of msg already delete at stickyMessageSet so tell cleary to console
     if (error instanceof DiscordAPIError && error.code === 10_008) {
-      console.error(`[StickyMessage] already delete old message!`)
+      log.error(`already delete old message!`)
     } else {
-      console.error(
-        `error while update sticky message ${(error as Error).message}`,
-      )
+      log.error(`error while update sticky message`, error)
     }
   } finally {
     resetCounter(message.channelId)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ if (process.argv.includes('--smoke')) {
   console.info(`[SMOKE] OK, database connection is working!`)
 
   // Attempt to load handlers
-  new Bot().loadHandlers()
+  await new Bot().init()
   console.info(`[SMOKE] OK, loading handlers is working!`)
 } else {
   // Run the bot

--- a/src/types/BotContext.ts
+++ b/src/types/BotContext.ts
@@ -2,6 +2,8 @@ import { Client } from 'discord.js'
 
 import { RuntimeConfiguration } from '@/utils/RuntimeConfiguration'
 
+import { Logger } from './Logger'
+
 /**
  * A shared context object that is passed to all command handlers.
  */
@@ -15,4 +17,9 @@ export interface BotContext {
    * Access runtime configuration.
    */
   readonly runtimeConfiguration: RuntimeConfiguration
+
+  /**
+   * Logger.
+   */
+  readonly log: Logger
 }

--- a/src/types/Logger.ts
+++ b/src/types/Logger.ts
@@ -1,0 +1,4 @@
+export interface Logger {
+  info(message: string): void
+  error(message: string, error?: unknown): void
+}

--- a/src/types/PluginContext.ts
+++ b/src/types/PluginContext.ts
@@ -1,7 +1,10 @@
 import { ClientEvents } from 'discord.js'
 
+import { BotContext } from './BotContext'
 import { CommandConfig } from './CommandConfig'
 import { EventHandlerConfig } from './EventHandlerConfig'
+
+export type PluginInitializer = (botContext: BotContext) => Promise<void>
 
 export interface PluginContext {
   /**
@@ -15,4 +18,10 @@ export interface PluginContext {
   addEventHandler<K extends keyof ClientEvents>(
     config: EventHandlerConfig<K>,
   ): void
+
+  /**
+   * Add an initialization logic to the bot.
+   * Bot will not start until all initializations are done.
+   */
+  addInitializer(init: PluginInitializer): void
 }

--- a/src/utils/createLogger.ts
+++ b/src/utils/createLogger.ts
@@ -1,0 +1,9 @@
+import { Logger } from '@/types/Logger'
+
+export function createLogger(prefix: string): Logger {
+  return {
+    info: (message: string) => console.info(`${prefix} ${message}`),
+    error: (message: string, error?: unknown) =>
+      console.error(`${prefix} ${message}`, error),
+  }
+}


### PR DESCRIPTION
# Description

## problem 1 - logging

when many events are happening at once, we want to be able to differentiate between errors between event A vs event B

this PR

- introduces a `Logger` interface
  - update all features to use the logger
  - send a logger with different prefix to each command/event handler

## problem 2 - initialization

![image](https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/1def1eb4-7bbb-48e2-b53b-b0a7947a5b38)

there is feature specific code in bot’s code which is supposed to be generic

this PR

- introduces an initializer system
  - any plugin that needs initialization logic can `addInitializer` during setup
  - bot will wait for all initializers to finish before logging in

## problem 3 - error handling

when an event handler encounters a problem, **the bot crashes**

this PR

- adds a try-catch handler in the event listener, so when there is an error, it is logged, but it doesn’t crash the bot

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor or other

## Screenshot

<img width="946" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/7ef2e7e8-d535-426d-a5e0-a3ab341c9ed6">

in the above picture, each event has a unique ID. when searching log, we can filter by that unique ID when so many things are happening at once.

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
