### PR TITLE
Make sticky message silent

### DIFF
--- a/src/features/stickyMessage/stickyMessages.spec.ts
+++ b/src/features/stickyMessage/stickyMessages.spec.ts
@@ -1,4 +1,4 @@
-import { Collection, Message } from 'discord.js'
+import { Collection, Message, MessageFlags } from 'discord.js'
 
 import { StickyMessage } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -224,6 +224,7 @@ describe('pushMessageToBottom', () => {
 
     expect(inputMessage.channel.send).toHaveBeenCalledWith({
       content: inputStickyMessageEntity.message,
+      flags: MessageFlags.SuppressNotifications,
     })
   })
 

--- a/src/features/stickyMessage/stickyMessages.ts
+++ b/src/features/stickyMessage/stickyMessages.ts
@@ -1,4 +1,4 @@
-import { DiscordAPIError, Message } from 'discord.js'
+import { DiscordAPIError, Message, MessageFlags } from 'discord.js'
 
 import { StickyMessage } from '@prisma/client'
 
@@ -50,6 +50,7 @@ export async function pushMessageToBottom(
 
     const newMessage = await message.channel.send({
       content: stickyMessage.message,
+      flags: MessageFlags.SuppressNotifications,
     })
 
     // update sticky message with new when successfully send new message


### PR DESCRIPTION
# Description

silent means it won't broadcast any push/desktop notification

Even though server this big Discord default notification to "only @mentions", but just in case anyway.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Screenshot

![image](https://github.com/kaogeek/kaogeek-discord-bot/assets/1791353/69b34538-7d81-477c-a00c-e7ecc5c3415e)

silent message have this cool icon

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
