### PR TITLE
allow enabling `preventEmojiSpam` on some channels

### DIFF
--- a/bot-config.example.toml
+++ b/bot-config.example.toml
@@ -17,10 +17,13 @@
   # If true, the bot will delete messages that only contains emojis.
   enabled = false
 
-  # Set a list of channels where the bot will delete messages that only contains emojis
+  # Channel IDs where the bot will delete messages that only contains emojis
   # even if the `enabled` option is set to false.
   enabledChannels = []
 
-  # Set a list of channels where the bot will not delete messages that only contains emojis.
+  # Channel IDs where the bot will not delete messages that only contains emojis.
   # This overrides the `enabled` and `enabledChannels` options.
   disabledChannels = []
+
+  # Role IDs who bypass the emoji spam prevention.
+  bypassRoles = []

--- a/bot-config.example.toml
+++ b/bot-config.example.toml
@@ -16,3 +16,11 @@
 [preventEmojiSpam]
   # If true, the bot will delete messages that only contains emojis.
   enabled = false
+
+  # Set a list of channels where the bot will delete messages that only contains emojis
+  # even if the `enabled` option is set to false.
+  enabledChannels = []
+
+  # Set a list of channels where the bot will not delete messages that only contains emojis.
+  # This overrides the `enabled` and `enabledChannels` options.
+  disabledChannels = []

--- a/src/features/preventEmojiSpam/index.ts
+++ b/src/features/preventEmojiSpam/index.ts
@@ -3,6 +3,8 @@ import { Events } from 'discord.js'
 import { definePlugin } from '@/types/definePlugin'
 import isOnlyEmoji from '@/utils/isOnlyEmoji'
 
+import { isEmojiPreventionEnabled } from './isEmojiPreventionEnabled'
+
 export default definePlugin({
   name: 'preventEmojiSpam',
   setup: (pluginContext) => {
@@ -11,13 +13,14 @@ export default definePlugin({
       once: false,
       execute: async (botContext, message) => {
         const { runtimeConfiguration, log } = botContext
+        const config = runtimeConfiguration.data.preventEmojiSpam
         // if has only emoji -> delete message
         if (isOnlyEmoji(message.content)) {
           try {
             log.info(
               `Message with only emoji: ${message.id} by ${message.author}`,
             )
-            if (runtimeConfiguration.data.preventEmojiSpam.enabled) {
+            if (isEmojiPreventionEnabled(config, message.channel)) {
               await message.delete()
             }
           } catch (error) {

--- a/src/features/preventEmojiSpam/index.ts
+++ b/src/features/preventEmojiSpam/index.ts
@@ -15,12 +15,14 @@ export default definePlugin({
         const { runtimeConfiguration, log } = botContext
         const config = runtimeConfiguration.data.preventEmojiSpam
         // if has only emoji -> delete message
-        if (isOnlyEmoji(message.content)) {
+        if (isOnlyEmoji(message.content) && message.member) {
           try {
             log.info(
-              `Message with only emoji: ${message.id} by ${message.author}`,
+              `Message with only emoji: ${message.id} by ${message.member}`,
             )
-            if (isEmojiPreventionEnabled(config, message.channel)) {
+            if (
+              isEmojiPreventionEnabled(config, message.channel, message.member)
+            ) {
               await message.delete()
             }
           } catch (error) {

--- a/src/features/preventEmojiSpam/isEmojiPreventionEnabled.spec.ts
+++ b/src/features/preventEmojiSpam/isEmojiPreventionEnabled.spec.ts
@@ -5,28 +5,46 @@ import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
 import { isEmojiPreventionEnabled } from './isEmojiPreventionEnabled'
 
 const config: RuntimeConfigurationSchema['preventEmojiSpam'] = {
-  enabled: true,
+  enabled: false,
   enabledChannels: ['1', '4'],
   disabledChannels: ['2', '4'],
+  bypassRoles: [],
+}
+
+const member = {
+  roles: {
+    cache: {
+      has: (roleId: string) => roleId === '99',
+    },
+  },
 }
 
 test('enabled', () => {
-  expect(isEmojiPreventionEnabled(config, { id: '3' })).toBe(true)
+  const testConfig = { ...config, enabled: true }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '3' }, member)).toBe(true)
 })
 
 test('disabled', () => {
-  const testConfig = { ...config, enabled: false }
-  expect(isEmojiPreventionEnabled(testConfig, { id: '2' })).toBe(false)
+  const testConfig = { ...config }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '2' }, member)).toBe(false)
 })
 
 test('enabledChannels', () => {
-  expect(isEmojiPreventionEnabled(config, { id: '1' })).toBe(true)
+  const testConfig = { ...config }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '1' }, member)).toBe(true)
 })
 
 test('disabledChannels', () => {
-  expect(isEmojiPreventionEnabled(config, { id: '2' })).toBe(false)
+  const testConfig = { ...config, enabled: true }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '2' }, member)).toBe(false)
 })
 
 test('disabledChannels wins over enabledChannels', () => {
-  expect(isEmojiPreventionEnabled(config, { id: '4' })).toBe(false)
+  const testConfig = { ...config, enabled: false }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '4' }, member)).toBe(false)
+})
+
+test('role bypass', () => {
+  const testConfig = { ...config, enabled: true, bypassRoles: ['99'] }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '3' }, member)).toBe(false)
 })

--- a/src/features/preventEmojiSpam/isEmojiPreventionEnabled.spec.ts
+++ b/src/features/preventEmojiSpam/isEmojiPreventionEnabled.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+
+import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
+
+import { isEmojiPreventionEnabled } from './isEmojiPreventionEnabled'
+
+const config: RuntimeConfigurationSchema['preventEmojiSpam'] = {
+  enabled: true,
+  enabledChannels: ['1', '4'],
+  disabledChannels: ['2', '4'],
+}
+
+test('enabled', () => {
+  expect(isEmojiPreventionEnabled(config, { id: '3' })).toBe(true)
+})
+
+test('disabled', () => {
+  const testConfig = { ...config, enabled: false }
+  expect(isEmojiPreventionEnabled(testConfig, { id: '2' })).toBe(false)
+})
+
+test('enabledChannels', () => {
+  expect(isEmojiPreventionEnabled(config, { id: '1' })).toBe(true)
+})
+
+test('disabledChannels', () => {
+  expect(isEmojiPreventionEnabled(config, { id: '2' })).toBe(false)
+})
+
+test('disabledChannels wins over enabledChannels', () => {
+  expect(isEmojiPreventionEnabled(config, { id: '4' })).toBe(false)
+})

--- a/src/features/preventEmojiSpam/isEmojiPreventionEnabled.ts
+++ b/src/features/preventEmojiSpam/isEmojiPreventionEnabled.ts
@@ -1,0 +1,18 @@
+import { Channel } from 'discord.js'
+
+import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
+
+export function isEmojiPreventionEnabled(
+  config: RuntimeConfigurationSchema['preventEmojiSpam'],
+  channel: Pick<Channel, 'id'>,
+) {
+  if (config.disabledChannels.includes(channel.id)) {
+    return false
+  }
+
+  if (config.enabledChannels.includes(channel.id)) {
+    return true
+  }
+
+  return config.enabled
+}

--- a/src/features/preventEmojiSpam/isEmojiPreventionEnabled.ts
+++ b/src/features/preventEmojiSpam/isEmojiPreventionEnabled.ts
@@ -5,6 +5,7 @@ import { RuntimeConfigurationSchema } from '@/utils/RuntimeConfigurationSchema'
 export function isEmojiPreventionEnabled(
   config: RuntimeConfigurationSchema['preventEmojiSpam'],
   channel: Pick<Channel, 'id'>,
+  member: { roles: { cache: { has: (roleId: string) => boolean } } },
 ) {
   if (config.disabledChannels.includes(channel.id)) {
     return false
@@ -12,6 +13,10 @@ export function isEmojiPreventionEnabled(
 
   if (config.enabledChannels.includes(channel.id)) {
     return true
+  }
+
+  if (config.bypassRoles.some((roleId) => member.roles.cache.has(roleId))) {
+    return false
   }
 
   return config.enabled

--- a/src/utils/RuntimeConfigurationSchema.ts
+++ b/src/utils/RuntimeConfigurationSchema.ts
@@ -27,6 +27,7 @@ export const RuntimeConfigurationSchema = z
         enabled: z.boolean().default(true),
         enabledChannels: z.array(z.string()).default([]),
         disabledChannels: z.array(z.string()).default([]),
+        bypassRoles: z.array(z.string()).default([]),
       })
       .default({}),
   })

--- a/src/utils/RuntimeConfigurationSchema.ts
+++ b/src/utils/RuntimeConfigurationSchema.ts
@@ -25,6 +25,8 @@ export const RuntimeConfigurationSchema = z
     preventEmojiSpam: z
       .object({
         enabled: z.boolean().default(true),
+        enabledChannels: z.array(z.string()).default([]),
+        disabledChannels: z.array(z.string()).default([]),
       })
       .default({}),
   })


### PR DESCRIPTION
# Description

Allow enabling `preventEmojiSpam` on some channels. Why? Some people flood emoji in Stage channel.

<img width="154" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/ff968b61-6ec2-4072-9e8e-2c7117c8a8d8">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot
N/A

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
