### PR TITLE
keep track of 🟥

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@(-.-)/env':

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,3 +111,13 @@ model TempRole {
 
   @@unique([userId, roleId])
 }
+
+model RedFlag {
+  id               String   @id @default(uuid())
+  actorId          String
+  flaggedUserId    String
+  flaggedChannelId String
+  flaggedMessageId String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+}

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -27,6 +27,7 @@ export class Bot {
       IntentsBitField.Flags.GuildMembers,
       IntentsBitField.Flags.GuildMessages,
       IntentsBitField.Flags.MessageContent,
+      IntentsBitField.Flags.GuildMessageReactions,
     ],
   })
   private readonly runtimeConfiguration = new RuntimeConfiguration()

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -8,6 +8,7 @@ import nominations from './nominations'
 import ping from './ping'
 import preventEmojiSpam from './preventEmojiSpam'
 import profileInspector from './profileInspector'
+import redFlagLogger from './redFlagLogger'
 import runtimeConfig from './runtimeConfig'
 import slowmode from './slowmode'
 import stickyMessage from './stickyMessage'
@@ -24,6 +25,7 @@ export default [
   ping,
   preventEmojiSpam,
   profileInspector,
+  redFlagLogger,
   runtimeConfig,
   slowmode,
   stickyMessage,

--- a/src/features/redFlagLogger/index.ts
+++ b/src/features/redFlagLogger/index.ts
@@ -1,0 +1,33 @@
+import { Events } from 'discord.js'
+
+import { prisma } from '@/prisma'
+import { definePlugin } from '@/types/definePlugin'
+
+export default definePlugin({
+  name: 'redFlagLogger',
+  setup: (pluginContext) => {
+    pluginContext.addEventHandler({
+      eventName: Events.MessageReactionAdd,
+      once: false,
+      execute: async (botContext, reaction, user) => {
+        const redFlagEmojiIdentifier = '%F0%9F%9F%A5' // 🟥
+        if (reaction.emoji.identifier !== redFlagEmojiIdentifier) return
+        const author = reaction.message.author
+        if (!author) return
+        const channel = reaction.message.channel
+        if (!channel) return
+        botContext.log.info(
+          `actor=${user.id} message=${reaction.message.id} messageAuthor=${author.id}`,
+        )
+        await prisma.redFlag.create({
+          data: {
+            actorId: user.id,
+            flaggedChannelId: reaction.message.channel.id,
+            flaggedMessageId: reaction.message.id,
+            flaggedUserId: author.id,
+          },
+        })
+      },
+    })
+  },
+})


### PR DESCRIPTION
# Description

in the Discord server, an organic way that people flag a message as "possibly not good" is by putting a "red square" emoji on it

<img width="154" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/ff968b61-6ec2-4072-9e8e-2c7117c8a8d8">

this PR simply saves this information to console log and database. it may be useful for future.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot

<img width="1388" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/cc645f0c-6a26-49cd-a780-690e4ece4ada">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
