### PR TITLE
docs: encourage dev to use corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,30 @@ Discord bot for KaoGeek, built with TypeScript and [discord.js](https://discord.
 
 1. Make sure to use same node version as specified in `.nvmrc` by using [nvm](https://github.com/nvm-sh/nvm)
 
-```bash
-nvm use
-```
+   ```bash
+   nvm use
+   ```
 
-If not installed, use `nvm install` to install specified version in `.nvmrc`
-(at the time of writing `lts/hydrogen`)
+   If not installed, use `nvm install` to install specified version in `.nvmrc`
+   (at the time of writing `lts/hydrogen`)
 
 2. Enable [Corepack](https://nodejs.org/api/corepack.html) (if not yet),
    this will automatically install `pnpm` with the version specified in
    `package.json#packageManager`.
 
-```bash
-corepack enable
-```
+   ```bash
+   corepack enable
+   ```
 
-This will ensure all developers use the same version of `pnpm`.
-Corepack will automatically switch pnpm's version when you switch to
-different workspace.
+   This will ensure all developers use the same version of `pnpm`.
+   Corepack will automatically switch pnpm's version when you switch to
+   different workspace.
 
 3. Install dependencies
 
-```bash
-pnpm install
-```
+   ```bash
+   pnpm install
+   ```
 
 ## Discord Bot & Server Setup (For Development)
 

--- a/README.md
+++ b/README.md
@@ -2,28 +2,34 @@
 
 Discord bot for KaoGeek, built with TypeScript and [discord.js](https://discord.js.org)
 
-## Setup
+## Workspace Setup
 
-- Make sure to use same node version as specified in `.nvmrc` by using [nvm](https://github.com/nvm-sh/nvm)
+1. Make sure to use same node version as specified in `.nvmrc` by using [nvm](https://github.com/nvm-sh/nvm)
 
-  ```bash
-  nvm use
-  ```
+```bash
+nvm use
+```
 
-  If not installed, use `nvm install` to install specified version in `.nvmrc`
-  (at the time of writing `lts/hydrogen`)
+If not installed, use `nvm install` to install specified version in `.nvmrc`
+(at the time of writing `lts/hydrogen`)
 
-- Install [pnpm](https://pnpm.io/installation) if you don't have one installed, you can install using npm
+2. Enable [Corepack](https://nodejs.org/api/corepack.html) (if not yet),
+   this will automatically install `pnpm` with the version specified in
+   `package.json#packageManager`.
 
-  ```bash
-  npm install -g pnpm
-  ```
+```bash
+corepack enable
+```
 
-- Install dependencies
+This will ensure all developers use the same version of `pnpm`.
+Corepack will automatically switch pnpm's version when you switch to
+different workspace.
 
-  ```bash
-  pnpm install
-  ```
+3. Install dependencies
+
+```bash
+pnpm install
+```
 
 ## Discord Bot & Server Setup (For Development)
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "vitest": "0.31.4"
   },
   "engines": {
-    "node": "^16.13 || ^18.12",
-    "pnpm": ">=8"
+    "node": "^18.12",
+    "pnpm": ">=8.6"
   },
   "packageManager": "pnpm@8.6.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@(-.-)/env':


### PR DESCRIPTION
# Description

This PR includes
- Update pnpm lockfile to version 6.1 because someone accidently mess with lockfile
- Update docs to encourage dev to use corepack
- No longer allow node 16 and old version of pnpm

## Why corepack?

`corepack enable` and corepack manage pnpm version for you.
When you switch to another project (switching directory). pnpm version is automatically switched based on what is set on that project.

## Type of change

- [X] Refactor or other

# Checklist:

- [X] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
