### PR TITLE
chore: group renovate deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,12 +10,16 @@
   "packageRules": [
     {
       "packagePatterns": ["*"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "dependencies (non-major)"
+      "enabled": true
     },
     {
       "packageNames": ["node"],
       "enabled": false
+    },
+    {
+      "packagePatterns": ["*"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dependencies (non-major)"
     }
   ],
   "vulnerabilityAlerts": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,8 @@
   "packageRules": [
     {
       "packagePatterns": ["*"],
-      "enabled": true
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dependencies (non-major)"
     },
     {
       "packageNames": ["node"],


### PR DESCRIPTION
# Description

Renovate should now group all non-major dependencies into a single PR. Should reduce number of PRs that it open.

## Type of change

- [X] Refactor or other

# Checklist:

- [X] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [X] I have performed a self-review of my own code
