### PR TITLE
chore(deps): use version number for gh actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,10 +98,10 @@ jobs:
       - uses: actions/checkout@v3
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@bdd549bec0b79f87fdf6064e966f34404a39cc33
+        uses: docker/setup-buildx-action@v2
       - name: Build Docker image
         id: build-and-push
-        uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf
+        uses: docker/build-push-action@v4
         with:
           context: .
           load: true


### PR DESCRIPTION
# Description

Change to number version so renovate can handle it better.

## Type of change

- [X] Refactor or other

# Checklist:

- [X] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [X] I have performed a self-review of my own code