### PR TITLE
upload image to public ghcr registry

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out code
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,19 +6,29 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v3
         name: Check out code
-
-      - uses: mr-smithers-excellent/docker-build-push@v6
-        name: Build & push Docker image to registry
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          image: kaogeek-discord-bot
-          tags: latest
-          registry: registry.yue.sh
-          dockerfile: Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ github.sha }}
       - name: Run deploy script
         uses: appleboy/ssh-action@v0.1.10
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,5 @@ COPY --chown=node:node --from=builder /app/dist ./dist
 COPY bot-config.example.toml ./
 
 CMD ["dist/index.js"]
+ARG APP_VERSION=unknown
+ENV APP_VERSION=${APP_VERSION}


### PR DESCRIPTION
# Description

Seems like `registry.yue.sh` is down.

<img width="729" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/c80a9a9e-e37e-49a5-af33-2d192bbf0410">

To optimize, we are migrating to GitHub Packages instead.

- Docker package is now published publicly here: <https://github.com/kaogeek/kaogeek-discord-bot/pkgs/container/kaogeek-discord-bot>
- Used the official action to build image. This makes image build faster (reduce time to deploy by ~1.5 minute).

## Type of change

- [x] Refactor or other

## Screenshot

<img width="770" alt="image" src="https://github.com/kaogeek/kaogeek-discord-bot/assets/193136/a16e8796-db23-422d-a36a-2d4cee9c26ee">

# Checklist:

- [x] I have run `pnpm format` and my code don't have any linting issues
  <!-- Please run `pnpm lint` to fix any bad practices / issues -->
  <!-- Code with formatting or ESLint error will not be accepted -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
